### PR TITLE
Feat/value persistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The configuration file is a JSON dictionary containing:
 - database connection details
 - list of databases to dump
 - list of tables with replacements or transformers
+  - Seeder - one column can be used as a row-seeder to get repeatability in consecutive dumps
+  - keepers - some rows can be kept as is, if a specified column matches a regular expression
   - columns with replacements or transformers
   - options to restrict output
     - `where` - Added to the query when retrieving data to dump: `... WHERE xxx...`
@@ -132,6 +134,18 @@ An example configuration, and configurations for popular applications, exist in 
                 "$options": { -- Only options to limit data, no replacements
                     "where": "is_active=1"
                 }
+            }
+        }
+        "databaseThree": {
+            "users": {
+                "@seed": "id", -- Seed each row using user id, to get repeatability
+                "@keepif": { -- Keep all rows with emails using domain @ourdomain.com intact
+                    "column": "email",
+                    "regex": "^.*@ourdomain.com$"
+                }
+                "first_name": "@user(current_user).firstName",
+                "last_name": "@user(current_user).lastName",
+                "email": "@user(current_user).email", - email will be based on the first and last names
             }
         }
     }

--- a/private-dump
+++ b/private-dump
@@ -51,38 +51,45 @@ foreach ($databases as $databaseName => $tables) {
         $dumper->setTableWheres($tableWheres);
     }
 
-    $dumper->setTransformColumnValueHook(function ($tableName, $colName, $colValue, $row) use ($tables, $transformer) {
-        // No transformers for this table
+    $dumper->setTransformTableRowHook(function ($tableName, array $row) use ($tables, $transformer) {
         if (!array_key_exists($tableName, $tables)) {
-            return $colValue;
+            return $row;
         }
 
-        // This column doesn't have a transformer
-        if (!array_key_exists($colName, $tables[$tableName])) {
-            return $colValue;
+        $tableConfig = $tables[$tableName];
+
         }
 
-        $columnReplacer = $tables[$tableName][$colName];
-
-        // Key value store, but also possible $options
-        if (is_array($columnReplacer)) {
-            // Key value store - $where on a different column name
-            // If the value matches a key in '$transformers' then we can replace the value as normal, otherwise
-            //    we will return the value as it is
-            if (!empty($columnReplacer['$link'])) {
-                foreach ($columnReplacer['$transformers'] as $associateColumnValue => $replacer) {
-                    // If this colValue == associate_column's value, then we can replace
-                    if ($associateColumnValue == $row[$columnReplacer['$link']]) {
-                        return $transformer->transform($colValue, $replacer);
-                    }
-                }
+        foreach ($row as $colName => $colValue) {
+            if (!array_key_exists($colName, $tables[$tableName])) {
+                continue;
             }
 
-            // Backup - return same column value if an array and no ^ transformer above
-            return $colValue;
+           $columnReplacer = $tables[$tableName][$colName];
+
+            // Key value store, but also possible $options
+            if (is_array($columnReplacer)) {
+                // Key value store - $where on a different column name
+                // If the value matches a key in '$transformers' then we can replace the value as normal, otherwise
+                //    we will return the value as it is
+                if (!empty($columnReplacer['$link'])) {
+                    foreach ($columnReplacer['$transformers'] as $associateColumnValue => $replacer) {
+                        // If this colValue == associate_column's value, then we can replace
+                        if ($associateColumnValue == $row[$columnReplacer['$link']]) {
+                            $row[$colName] = $transformer->transform($colValue, $replacer);
+                            break;
+                        }
+                    }
+                }
+
+                // Backup - use same column value if an array and no ^ transformer above
+                continue;
+            }
+
+            $row[$colName] = $transformer->transform($colValue, $columnReplacer);
         }
 
-        return $transformer->transform($colValue, $columnReplacer);
+        return $row;
     });
 
     try {

--- a/private-dump
+++ b/private-dump
@@ -58,6 +58,8 @@ foreach ($databases as $databaseName => $tables) {
 
         $tableConfig = $tables[$tableName];
 
+        $transformer->forget();
+
         if (isset($tableConfig['@seed']) && is_numeric($row[$tableConfig['@seed']])) {
             $transformer->seed((int)$row[$tableConfig['@seed']]);
         }

--- a/private-dump
+++ b/private-dump
@@ -58,6 +58,10 @@ foreach ($databases as $databaseName => $tables) {
 
         $tableConfig = $tables[$tableName];
 
+        if (isset($tableConfig['@seed']) && is_numeric($row[$tableConfig['@seed']])) {
+            $transformer->seed((int)$row[$tableConfig['@seed']]);
+        }
+
         }
 
         foreach ($row as $colName => $colValue) {

--- a/private-dump
+++ b/private-dump
@@ -62,6 +62,20 @@ foreach ($databases as $databaseName => $tables) {
             $transformer->seed((int)$row[$tableConfig['@seed']]);
         }
 
+        if (isset($tableConfig['@keepif'])) {
+            if (!isset($tableConfig['@keepif']['regex']) || !isset($tableConfig['@keepif']['column'])) {
+                echo "@keepif requires one column and one regex key".PHP_EOL;
+                exit(1);
+            }
+
+            $keepIfColumn = $tableConfig['@keepif']['column'];
+            $keepIfRegexp = '/' . $tableConfig['@keepif']['regex'] . '/';
+
+            if ($keepIfColumn !== null && array_key_exists($keepIfColumn, $row)) {
+                if (preg_match($keepIfRegexp, $row[$keepIfColumn]) === 1) {
+                    return $row;
+                }
+            }
         }
 
         foreach ($row as $colName => $colValue) {

--- a/src/PrivateDump/Transformer.php
+++ b/src/PrivateDump/Transformer.php
@@ -166,6 +166,9 @@ class Transformer
         }
 
 
+        // Check if replacement matches the "@replacementObject(name).accessor" format,
+        // in which case a named object will be placed in the object cache.
+
         $object = null;
         $matches = null;
         if (preg_match('/^@(\w+)\((\w+\))\.(.*)$/', $replacement, $matches)) {
@@ -175,12 +178,14 @@ class Transformer
             if (array_key_exists($objectName, $this->objectCache)) {
                 $object = $this->objectCache[$objectName];
             } else {
-                $getObjectMethod = sprintf('transformObject%s', $objectType);
+                $getObjectMethod = sprintf('transformObject%s', ucwords(strtolower($objectType)));
                 if (method_exists($this, $getObjectMethod)) {
                     $object = $this->$getObjectMethod();
                     $this->objectCache[$objectName] = $object;
                 }
             }
+
+            // Replace with only the accessor part
             $replacement = "@{$matches[3]}";
         }
 

--- a/src/PrivateDump/Transformer.php
+++ b/src/PrivateDump/Transformer.php
@@ -41,6 +41,16 @@ class Transformer
     }
 
     /**
+     * Seed the faker library.
+     *
+     * @param int $value
+     */
+    public function seed($value)
+    {
+        $this->faker->seed($value);
+    }
+
+    /**
      * Generate random string.
      *
      * @param string $value

--- a/src/PrivateDump/Transformer.php
+++ b/src/PrivateDump/Transformer.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Param;
 class Transformer
 {
     public static $booted = false;
+    private $objectCache = [];
     private $faker;
     private $transformerAliases = [
         'lorem'           => 'sentence',
@@ -48,6 +49,14 @@ class Transformer
     public function seed($value)
     {
         $this->faker->seed($value);
+    }
+
+    /**
+     * Forget cached values
+     */
+    public function forget()
+    {
+        $this->objectCache = [];
     }
 
     /**
@@ -127,6 +136,19 @@ class Transformer
         );
     }
 
+    protected function transformObjectUser()
+    {
+        $user = new \stdClass();
+
+        $user->firstName = $this->faker->firstName();
+        $user->lastName = $this->faker->lastName();
+        $user->email = sprintf('%s.%s@example.com', mb_strtolower($user->firstName), mb_strtolower($user->lastName));
+        $user->userName = $user->email;
+        $user->fullName = "{$user->firstName} {$user->lastName}";
+
+        return $user;
+    }
+
     /**
      * Transform given value based on the replacement string provided from the JSON.
      *
@@ -143,6 +165,25 @@ class Transformer
             return $replacement;
         }
 
+
+        $object = null;
+        $matches = null;
+        if (preg_match('/^@(\w+)\((\w+\))\.(.*)$/', $replacement, $matches)) {
+            $objectType = $matches[1];
+            $objectName = $matches[2];
+
+            if (array_key_exists($objectName, $this->objectCache)) {
+                $object = $this->objectCache[$objectName];
+            } else {
+                $getObjectMethod = sprintf('transformObject%s', $objectType);
+                if (method_exists($this, $getObjectMethod)) {
+                    $object = $this->$getObjectMethod();
+                    $this->objectCache[$objectName] = $object;
+                }
+            }
+            $replacement = "@{$matches[3]}";
+        }
+
         // Faker Transformer has modifiers, let's use them
         if (strpos($replacement, '|') !== false) {
             [$replacement, $modifiers] = explode('|', $replacement, 2);
@@ -152,16 +193,20 @@ class Transformer
         $replacement = preg_replace('/^@/', '', $replacement);
         $originalReplacement = $replacement;
 
-        if (array_key_exists($replacement, $this->transformerAliases)) {
+        if ($object === null && array_key_exists($replacement, $this->transformerAliases)) {
             $replacement = $this->transformerAliases[$replacement];
         }
 
         $ownMethod = sprintf('transform%s', ucwords(strtolower($replacement)));
 
         try {
-            $newValue = method_exists($this, $ownMethod)
-                ? $this->$ownMethod($value, ...$modifiers)
-                : $this->faker->$replacement(...$modifiers);
+            if ($object !== null) {
+                $newValue = $object->$replacement;
+            } else {
+                $newValue = method_exists($this, $ownMethod)
+                    ? $this->$ownMethod($value, ...$modifiers)
+                    : $this->faker->$replacement(...$modifiers);
+            }
         } catch (\Exception $e) {
             echo sprintf('[error] Transformer not found, please fix and retry: [%s]', $originalReplacement).PHP_EOL;
             exit(9);

--- a/tests/PrivateDump/TransformerTest.php
+++ b/tests/PrivateDump/TransformerTest.php
@@ -68,4 +68,35 @@ class TransformerTest extends TestCase
         $this->assertEquals('admin@example.com', $this->transformer->transform('admin@example.com', '@original'));
         $this->assertEquals('admin@exa', $this->transformer->transform('admin@example.com', '@original|9'));
     }
+
+    /** @test */
+    public function seeder_works()
+    {
+        $this->transformer->seed(123);
+
+        $firstEmail = $this->transformer->transform('some@example.com', '@email');
+        $secondEmail = $this->transformer->transform('some@example.com', '@email');
+
+        $this->transformer->seed(123);
+        $thirdEmail = $this->transformer->transform('some@example.com', '@email');
+        $fourthEmail = $this->transformer->transform('some@example.com', '@email');
+
+        $this->assertEquals($firstEmail, $thirdEmail);
+        $this->assertEquals($secondEmail, $fourthEmail);
+    }
+
+    /** @test */
+    public function object_works()
+    {
+        $user1Email = $this->transformer->transform('', '@user(user1).email');
+        $user1FirstName = $this->transformer->transform('', '@user(user1).firstName');
+        $user1LastName = $this->transformer->transform('', '@user(user1).lastName');
+
+        $user2FirstName = $this->transformer->transform('', '@user(user2).firstName');
+        $user2LastName = $this->transformer->transform('', '@user(user2).lastName');
+
+        $this->assertEquals($user1Email, sprintf('%s.%s@example.com', mb_strtolower($user1FirstName), mb_strtolower($user1LastName)));
+
+        $this->assertNotEquals($user1FirstName, $user2FirstName);
+    }
 }


### PR DESCRIPTION
This PR is best read one commit at a time.

Adds support for:

* `@seed` - allows seeding Faker on each row based on an arbitrary column
* `@keepif` - allows retaining some rows based on regex matching of original data
* Compound objects - allows consistency per row, for example an email can be created using firstName, lastName, so that they are not individually randomised.

Example configuration showing new features:
```json
{
    "databases": {
        "test": {
            "users": {
                "@seed": "id",
                "@keepif": {
                    "column": "email",
                    "regex": "^.*@ourdomain.com$"
                },
                "name": "@user(user).fullName",
                "username": "@user(user).userName",
                "email": "@user(user).email",
                "password": "@password",
                "avatar": "@avatarUrl",
                "last_login_ip": "@ipv4",
                "mailchimp_hash": "",
                "phone_number": "@phoneNumber",
                "remember_token": "",
                "slack_handle": ""

            }
        }
    }
}
```